### PR TITLE
Tinkerforge Sensoren eingebunden

### DIFF
--- a/core/TinkerforgeSensoren.py
+++ b/core/TinkerforgeSensoren.py
@@ -1,0 +1,53 @@
+from tinkerforge.ip_connection import IPConnection
+from tinkerforge.bricklet_temperature import BrickletTemperature
+
+class TinkerforgeSensor(object):
+    
+    def __init__(self, uid, int_MW=9,Acc=4, host='localhost', port='4223'):
+        self.Acc = Acc
+		self.int_MW = int_MW
+        self.uid = uid
+        self.host = host
+        self.port = port
+        self.wert = 0
+        self.werte = []
+        self.mittelwert = 0
+        self.ipconnection = IPConnection()
+        self.sensor = initSensor()
+    
+    def initSensor(self):
+        pass
+
+    def ReadValue(self):
+        pass
+
+    def Update(self):
+        self.ReadValue()
+        if len(self.werte) == self.int_MW:
+            self.Mittelwert()
+            self.werte = []
+
+    def Mittelwert(self):
+        self.mittelwert = reduce(lambda x, y: x + y, self.werte) / len(self.werte)
+
+class TinkerforgeTemperature(TinkerforgeSensor):
+
+    def initSensor(self):
+        s = BrickletTemperature(self.uid, self.ipconnection)
+        self.ipconnection.connect(self.host, self.port)
+        return s
+
+    def ReadValue(self):
+        self.wert = self.sensor.get_temperature() / 100
+        self.ipconnection.disconnect()
+
+class TinkerforgeHumidity(TinkerforgeSensor):
+
+    def initSensor(self):
+        s = BrickletHumdity(self.uid, self.ipconnection)
+        self.ipconnection.connect(self.host, self.port)
+        return s
+
+    def ReadValue(self):
+        self.wert = self.sensor.get_humidity() / 10
+        self.ipconnection.disconnect()

--- a/core/measure.py
+++ b/core/measure.py
@@ -5,13 +5,14 @@ import MySQLdb as mysql
 import spidev
 import time
 import db_handle
-from mysensors import *
+from TinkerforgeSensoren import *
 
 
 if __name__ == "__main__":
 	intervall = 60*15 # (15 Minuten)
-	TEMP = Temperatur(1, intervall, runden=3)
-	HUM = Feuchtigkeit(0, TEMP.wert, intervall, runden=3)
+	TEMP = TinkerforgeTemperature('123',intervall)
+	HUM = TinkerforgeHumidity('456',intervall)
+
 	i = 0
 
 	creds = db_handle.Credentials()


### PR DESCRIPTION
## Request

Request request request.... 
Tinkerforge Sensoren eingebunden, freigegeben zum Testen.
Die UID muss noch auf die des entsprechenden Sensors angepasst werden.
